### PR TITLE
Prevent broken symlinks

### DIFF
--- a/bin/xtea
+++ b/bin/xtea
@@ -1269,6 +1269,8 @@ if __name__ == '__main__':
         b_denovo=options.denovo
     ####
 
+        s_wfolder = os.path.abspath(s_wfolder)
+
         if s_wfolder[-1]!="/":
             s_wfolder+="/"
         if os.path.exists(s_wfolder) == False:

--- a/bin/xtea_hg19
+++ b/bin/xtea_hg19
@@ -4,6 +4,9 @@ import os
 from subprocess import *
 from optparse import OptionParser
 import ntpath
+
+from xtea import utils
+
 #import global_values
 ILLUMINA="illumina"
 X10="10X"
@@ -1172,6 +1175,8 @@ if __name__ == '__main__':
         b_slurm=options.slurm
         b_resume=options.resume
         b_denovo = options.denovo
+
+        s_wfolder = os.path.abspath(s_wfolder)
 
         if s_wfolder[-1]!="/":
             s_wfolder+="/"

--- a/bin/xtea_hg19
+++ b/bin/xtea_hg19
@@ -5,8 +5,6 @@ from subprocess import *
 from optparse import OptionParser
 import ntpath
 
-from xtea import utils
-
 #import global_values
 ILLUMINA="illumina"
 X10="10X"

--- a/bin/xtea_long
+++ b/bin/xtea_long
@@ -484,6 +484,8 @@ if __name__ == '__main__':
         b_clean=options.clean
         i_peak_win = options.win #maximum window size when try to cluster the breakpoints
 
+        s_wfolder = os.path.abspath(s_wfolder)
+
         if s_wfolder[-1]!="/":
             s_wfolder+="/"
         if os.path.exists(s_wfolder) == False:


### PR DESCRIPTION
This PR simply resolves the path for the working directory. Previously, specification of a relative path as the `-p` parameter in the initial xTea call would result in broken symlinks during symlink creation in lines 623 or 691 of x_TEI_locator.py. Adding logic to resolve the path prevents this